### PR TITLE
Fix logic error in `_on_disconnect` that prevents reconnections.

### DIFF
--- a/aiophyn/mqtt.py
+++ b/aiophyn/mqtt.py
@@ -242,7 +242,7 @@ class MQTTClient:
         if self.disconnect_evt is not None:
             self.disconnect_evt.set()
             _LOGGER.info("Client disconnected, not attempting to reconnect")
-        elif self.is_connected():
+        elif not self.is_connected():
             # The server connection was dropped, attempt to reconnect
             _LOGGER.info("MQTT Server Disconnected, reason: %s", paho_mqtt.error_string(reason_code))
             self.reconnect_timer.cancel()


### PR DESCRIPTION
I noticed (due to the AWS outage) that the Phyn HA integration does not reconnect when it loses connection, but instead reports stale values indefinitely. Upon closer inspection, there is a logic error in the `_on_disconnect` handler that prevents the existing reconnection code from working. This pull request fixes this logic error.

I considered also implementing logic to mark the entities as "unavailable" during reconnection, but this seemed like a bit too much.